### PR TITLE
Move header/footer fetch to external script

### DIFF
--- a/about.html
+++ b/about.html
@@ -28,14 +28,7 @@
 
     <div id="footer"></div>
 
-    <script>
-        fetch('header.html')
-            .then(response => response.text())
-            .then(data => document.getElementById('header').innerHTML = data);
-        fetch('footer.html')
-            .then(response => response.text())
-            .then(data => document.getElementById('footer').innerHTML = data);
-    </script>
+    <script src="loadHeaderFooter.js"></script>
 
 </body>
 

--- a/bio.html
+++ b/bio.html
@@ -62,14 +62,7 @@
 
     <div id="footer"></div>
 
-    <script>
-        fetch('header.html')
-            .then(response => response.text())
-            .then(data => document.getElementById('header').innerHTML = data);
-        fetch('footer.html')
-            .then(response => response.text())
-            .then(data => document.getElementById('footer').innerHTML = data);
-    </script>
+    <script src="loadHeaderFooter.js"></script>
 
 </body>
 

--- a/contact.html
+++ b/contact.html
@@ -24,14 +24,7 @@
 
     <div id="footer"></div>
 
-    <script>
-        fetch('header.html')
-            .then(response => response.text())
-            .then(data => document.getElementById('header').innerHTML = data);
-        fetch('footer.html')
-            .then(response => response.text())
-            .then(data => document.getElementById('footer').innerHTML = data);
-    </script>
+    <script src="loadHeaderFooter.js"></script>
 
 </body>
 

--- a/faq.html
+++ b/faq.html
@@ -66,15 +66,7 @@
 
     <div id="footer"></div>
 
-    <script>
-        // Load external HTML files
-        fetch('header.html')
-            .then(response => response.text())
-            .then(data => document.getElementById('header').innerHTML = data);
-        fetch('footer.html')
-            .then(response => response.text())
-            .then(data => document.getElementById('footer').innerHTML = data);
-    </script>
+    <script src="loadHeaderFooter.js"></script>
 
 </body>
 

--- a/index.html
+++ b/index.html
@@ -46,14 +46,7 @@
 
     <div id="footer"></div>
 
-    <script>
-        fetch('header.html')
-            .then(response => response.text())
-            .then(data => document.getElementById('header').innerHTML = data);
-        fetch('footer.html')
-            .then(response => response.text())
-            .then(data => document.getElementById('footer').innerHTML = data);
-    </script>
+    <script src="loadHeaderFooter.js"></script>
     <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7650601790230278" crossorigin="anonymous"></script>
 </body>
 

--- a/join.html
+++ b/join.html
@@ -46,14 +46,9 @@
     </div>
 
     <div id="footer"></div>
+    <script src="loadHeaderFooter.js"></script>
 
     <script>
-        fetch('header.html')
-            .then(response => response.text())
-            .then(data => document.getElementById('header').innerHTML = data);
-        fetch('footer.html')
-            .then(response => response.text())
-            .then(data => document.getElementById('footer').innerHTML = data);
         function handleSubmit(event) {
             event.preventDefault(); 
             window.location.href = 'thankyou.html';

--- a/loadHeaderFooter.js
+++ b/loadHeaderFooter.js
@@ -1,0 +1,15 @@
+document.addEventListener('DOMContentLoaded', function () {
+  fetch('header.html')
+    .then(function (response) { return response.text(); })
+    .then(function (data) {
+      var header = document.getElementById('header');
+      if (header) header.innerHTML = data;
+    });
+
+  fetch('footer.html')
+    .then(function (response) { return response.text(); })
+    .then(function (data) {
+      var footer = document.getElementById('footer');
+      if (footer) footer.innerHTML = data;
+    });
+});

--- a/opportunities.html
+++ b/opportunities.html
@@ -59,14 +59,9 @@
     </div>
 
     <div id="footer"></div>
+    <script src="loadHeaderFooter.js"></script>
 
     <script>
-        fetch('header.html')
-            .then(response => response.text())
-            .then(data => document.getElementById('header').innerHTML = data);
-        fetch('footer.html')
-            .then(response => response.text())
-            .then(data => document.getElementById('footer').innerHTML = data);
 
         function calculateIncome() {
             const recruits = parseInt(document.getElementById('recruits').value) || 0;

--- a/privacy.html
+++ b/privacy.html
@@ -44,15 +44,7 @@
 
     <div id="footer"></div> <!-- Placeholder for footer content -->
 
-    <script>
-        // Load external HTML files
-        fetch('header.html')
-            .then(response => response.text())
-            .then(data => document.getElementById('header').innerHTML = data);
-        fetch('footer.html')
-            .then(response => response.text())
-            .then(data => document.getElementById('footer').innerHTML = data);
-    </script>
+    <script src="loadHeaderFooter.js"></script>
 
 </body>
 

--- a/terms.html
+++ b/terms.html
@@ -44,15 +44,7 @@
 
     <div id="footer"></div> <!-- Placeholder for footer content -->
 
-    <script>
-        // Load external HTML files
-        fetch('header.html')
-            .then(response => response.text())
-            .then(data => document.getElementById('header').innerHTML = data);
-        fetch('footer.html')
-            .then(response => response.text())
-            .then(data => document.getElementById('footer').innerHTML = data);
-    </script>
+    <script src="loadHeaderFooter.js"></script>
 
 </body>
 

--- a/testimonials.html
+++ b/testimonials.html
@@ -45,14 +45,7 @@
 
     <div id="footer"></div>
 
-    <script>
-        fetch('header.html')
-            .then(response => response.text())
-            .then(data => document.getElementById('header').innerHTML = data);
-        fetch('footer.html')
-            .then(response => response.text())
-            .then(data => document.getElementById('footer').innerHTML = data);
-    </script>
+    <script src="loadHeaderFooter.js"></script>
 
 </body>
 

--- a/thankyou.html
+++ b/thankyou.html
@@ -26,14 +26,7 @@
 
     <div id="footer"></div>
 
-    <script>
-        fetch('header.html')
-            .then(response => response.text())
-            .then(data => document.getElementById('header').innerHTML = data);
-        fetch('footer.html')
-            .then(response => response.text())
-            .then(data => document.getElementById('footer').innerHTML = data);
-    </script>
+    <script src="loadHeaderFooter.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- create `loadHeaderFooter.js` to fetch header.html and footer.html once
- include script across all pages
- remove duplicated inline fetch code

## Testing
- `grep -n "fetch('" -n *.html`

------
https://chatgpt.com/codex/tasks/task_b_68485f06f8bc83299ef750dce98342d5